### PR TITLE
DRYing up repetitive methods into tables.

### DIFF
--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -14,29 +14,6 @@ class Cipher
     ("a".."z").to_a << " "
   end
 
-  def encrypt_table(key, date)
-    tables = {}
-    tables[:a] = shift_table(a_shift_value(key, date))
-    tables[:b] = shift_table(b_shift_value(key, date))
-    tables[:c] = shift_table(c_shift_value(key, date))
-    tables[:d] = shift_table(d_shift_value(key, date))
-    tables
-  end
-
-  def decrypt_table(key, date)
-    tables = {}
-    tables[:a] = shift_table(a_shift_value(key, date) * -1)
-    tables[:b] = shift_table(b_shift_value(key, date) * -1)
-    tables[:c] = shift_table(c_shift_value(key, date) * -1)
-    tables[:d] = shift_table(d_shift_value(key, date) * -1)
-    tables
-  end
-
-  def shift_table(shift_value)
-    shifted_characters = character_index.rotate(shift_value)
-    table = character_index.zip(shifted_characters).to_h
-  end
-
   def encoded
     encoded = ""
     split_message = @message.chars

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -60,9 +60,7 @@ class Cipher
     decoded = ""
     split_message = @message.chars
     split_message.each_with_index do |character, index|
-      if !character_index.include?(character)
-        decoded << character
-      elsif ((index + 1)% 4) % 4 == 0
+      if ((index + 1)% 4) % 4 == 0
         decoded << decrypt_table(@key, @date)[:d][character]
       elsif ((index + 1)% 4) % 3 == 0
         decoded << decrypt_table(@key, @date)[:c][character]

--- a/lib/key.rb
+++ b/lib/key.rb
@@ -13,19 +13,13 @@ module Key
     format_to_char_length(selection, 5)
   end
 
-  def a_key_values(key)
-    (key[0] + key[1]).to_i
+  def key_table(key)
+    key_values = {}
+    key_values[:a] = (key[0] + key[1]).to_i
+    key_values[:b] = (key[1] + key[2]).to_i
+    key_values[:c] = (key[2] + key[3]).to_i
+    key_values[:d] = (key[3] + key[4]).to_i
+    key_values
   end
 
-  def b_key_values(key)
-    (key[1] + key[2]).to_i
-  end
-
-  def c_key_values(key)
-    (key[2] + key[3]).to_i
-  end
-
-  def d_key_values(key)
-    (key[3] + key[4]).to_i
-  end
 end

--- a/lib/offset.rb
+++ b/lib/offset.rb
@@ -18,28 +18,17 @@ module Offset
 
   def last_four_of_squared(date)
     squared_to_int = date.to_i ** 2
-    as_string = squared_to_int.to_s
-    last_four = as_string[-4,4]
+    last_four_of_string = squared_to_int.to_s
+    last_four_of_string[-4,4]
   end
 
-  def a_offset_values(date)
-    offset = last_four_of_squared(date)
-    offset[0].to_i
-  end
-
-  def b_offset_values(date)
-    offset = last_four_of_squared(date)
-    offset[1].to_i
-  end
-
-  def c_offset_values(date)
-    offset = last_four_of_squared(date)
-    offset[2].to_i
-  end
-
-  def d_offset_values(date)
-    offset = last_four_of_squared(date)
-    offset[3].to_i
+  def offset_table(date)
+    offset_values = {}
+    offset_values[:a] = last_four_of_squared(date)[0].to_i
+    offset_values[:b] = last_four_of_squared(date)[1].to_i
+    offset_values[:c] = last_four_of_squared(date)[2].to_i
+    offset_values[:d] = last_four_of_squared(date)[3].to_i
+    offset_values
   end
 
 end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -21,4 +21,27 @@ module Shift
     d_key_values(key) + d_offset_values(date)
   end
 
+  def encrypt_table(key, date)
+    tables = {}
+    tables[:a] = shift_table(a_shift_value(key, date))
+    tables[:b] = shift_table(b_shift_value(key, date))
+    tables[:c] = shift_table(c_shift_value(key, date))
+    tables[:d] = shift_table(d_shift_value(key, date))
+    tables
+  end
+
+  def decrypt_table(key, date)
+    tables = {}
+    tables[:a] = shift_table(a_shift_value(key, date) * -1)
+    tables[:b] = shift_table(b_shift_value(key, date) * -1)
+    tables[:c] = shift_table(c_shift_value(key, date) * -1)
+    tables[:d] = shift_table(d_shift_value(key, date) * -1)
+    tables
+  end
+
+  def shift_table(shift_value)
+    shifted_characters = character_index.rotate(shift_value)
+    table = character_index.zip(shifted_characters).to_h
+  end
+
 end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -5,43 +5,36 @@ module Shift
   include Key
   include Offset
 
-  def a_shift_value(key, date)
-    a_key_values(key) + a_offset_values(date)
-  end
-
-  def b_shift_value(key, date)
-    b_key_values(key) + b_offset_values(date)
-  end
-
-  def c_shift_value(key, date)
-    c_key_values(key) + c_offset_values(date)
-  end
-
-  def d_shift_value(key, date)
-    d_key_values(key) + d_offset_values(date)
-  end
-
   def encrypt_table(key, date)
     tables = {}
-    tables[:a] = shift_table(a_shift_value(key, date))
-    tables[:b] = shift_table(b_shift_value(key, date))
-    tables[:c] = shift_table(c_shift_value(key, date))
-    tables[:d] = shift_table(d_shift_value(key, date))
+    tables[:a] = conversion_table(shift_table(key, date)[:a])
+    tables[:b] = conversion_table(shift_table(key, date)[:b])
+    tables[:c] = conversion_table(shift_table(key, date)[:c])
+    tables[:d] = conversion_table(shift_table(key, date)[:d])
     tables
   end
 
   def decrypt_table(key, date)
     tables = {}
-    tables[:a] = shift_table(a_shift_value(key, date) * -1)
-    tables[:b] = shift_table(b_shift_value(key, date) * -1)
-    tables[:c] = shift_table(c_shift_value(key, date) * -1)
-    tables[:d] = shift_table(d_shift_value(key, date) * -1)
+    tables[:a] = conversion_table(shift_table(key, date)[:a] * -1)
+    tables[:b] = conversion_table(shift_table(key, date)[:b] * -1)
+    tables[:c] = conversion_table(shift_table(key, date)[:c] * -1)
+    tables[:d] = conversion_table(shift_table(key, date)[:d] * -1)
     tables
   end
 
-  def shift_table(shift_value)
+  def conversion_table(shift_value)
     shifted_characters = character_index.rotate(shift_value)
-    table = character_index.zip(shifted_characters).to_h
+    character_index.zip(shifted_characters).to_h
+  end
+
+  def shift_table(key, date)
+    shift_values = {}
+    shift_values[:a] = key_table(key)[:a] + offset_table(date)[:a]
+    shift_values[:b] = key_table(key)[:b] + offset_table(date)[:b]
+    shift_values[:c] = key_table(key)[:c] + offset_table(date)[:c]
+    shift_values[:d] = key_table(key)[:d] + offset_table(date)[:d]
+    shift_values
   end
 
 end

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -13,81 +13,28 @@ class CipherTest < Minitest::Test
     assert_equal " ", enigma.character_index.last
   end
 
-  def test_it_can_create_a_cipher_table_for_each_encrypt_shift
-    enigma = Enigma.new
-    enigma.encrypt("hello world", "02715", "040895")
+  def test_it_can_encode_a_message
+    cipher = Cipher.new("hello world", "02715", "040895")
 
-    a_expected = {
-      "a"=>"d", "b"=>"e", "c"=>"f", "d"=>"g", "e"=>"h", "f"=>"i","g"=>"j",
-      "h"=>"k", "i"=>"l", "j"=>"m", "k"=>"n", "l"=>"o", "m"=>"p", "n"=>"q",
-      "o"=>"r", "p"=>"s", "q"=>"t", "r"=>"u", "s"=>"v", "t"=>"w", "u"=>"x",
-      "v"=>"y", "w"=>"z", "x"=>" ", "y"=>"a", "z"=>"b", " "=>"c"
-      }
-
-    b_expected = {
-      "a"=>"a", "b"=>"b", "c"=>"c", "d"=>"d", "e"=>"e", "f"=>"f", "g"=>"g",
-      "h"=>"h", "i"=>"i", "j"=>"j", "k"=>"k", "l"=>"l", "m"=>"m", "n"=>"n",
-      "o"=>"o", "p"=>"p", "q"=>"q", "r"=>"r", "s"=>"s", "t"=>"t", "u"=>"u",
-      "v"=>"v", "w"=>"w", "x"=>"x", "y"=>"y", "z"=>"z", " "=>" "
-      }
-
-    c_expected = {
-      "a"=>"t", "b"=>"u", "c"=>"v", "d"=>"w", "e"=>"x", "f"=>"y", "g"=>"z",
-      "h"=>" ", "i"=>"a", "j"=>"b", "k"=>"c", "l"=>"d", "m"=>"e", "n"=>"f",
-      "o"=>"g", "p"=>"h", "q"=>"i", "r"=>"j", "s"=>"k", "t"=>"l", "u"=>"m",
-      "v"=>"n", "w"=>"o", "x"=>"p", "y"=>"q", "z"=>"r", " "=>"s"
-      }
-
-    d_expected = {
-      "a"=>"u", "b"=>"v", "c"=>"w", "d"=>"x", "e"=>"y", "f"=>"z", "g"=>" ",
-      "h"=>"a", "i"=>"b", "j"=>"c", "k"=>"d", "l"=>"e", "m"=>"f", "n"=>"g",
-      "o"=>"h", "p"=>"i", "q"=>"j", "r"=>"k", "s"=>"l", "t"=>"m", "u"=>"n",
-      "v"=>"o", "w"=>"p", "x"=>"q", "y"=>"r", "z"=>"s", " "=>"t"
-      }
-
-    assert_equal a_expected, enigma.encrypt_table("02715", "040895")[:a]
-    assert_equal b_expected, enigma.encrypt_table("02715", "040895")[:b]
-    assert_equal c_expected, enigma.encrypt_table("02715", "040895")[:c]
-    assert_equal d_expected, enigma.encrypt_table("02715", "040895")[:d]
+    assert_equal "keder ohulw", cipher.encoded
   end
 
-  def test_it_can_create_a_cipher_table_for_each_decrypt_shift
-    enigma = Enigma.new
-    enigma.decrypt("keder ohulw", "02715", "040895")
+  def test_it_can_encode_a_message_allows_special_characters_to_remain_unchanged
+    cipher = Cipher.new("he((o w0r!d", "02715", "040895")
 
-    a_expected = {
-      "a"=>"y", "b"=>"z", "c"=>" ", "d"=>"a", "e"=>"b", "f"=>"c", "g"=>"d",
-      "h"=>"e", "i"=>"f", "j"=>"g", "k"=>"h", "l"=>"i", "m"=>"j", "n"=>"k",
-      "o"=>"l", "p"=>"m", "q"=>"n", "r"=>"o", "s"=>"p", "t"=>"q", "u"=>"r",
-      "v"=>"s", "w"=>"t", "x"=>"u", "y"=>"v", "z"=>"w", " "=>"x"
-      }
-
-    b_expected = {
-      "a"=>"a", "b"=>"b", "c"=>"c", "d"=>"d", "e"=>"e", "f"=>"f", "g"=>"g",
-      "h"=>"h", "i"=>"i", "j"=>"j", "k"=>"k", "l"=>"l", "m"=>"m", "n"=>"n",
-      "o"=>"o", "p"=>"p", "q"=>"q", "r"=>"r", "s"=>"s", "t"=>"t", "u"=>"u",
-      "v"=>"v", "w"=>"w", "x"=>"x", "y"=>"y", "z"=>"z", " "=>" "
-      }
-
-    c_expected = {
-      "a"=>"i", "b"=>"j", "c"=>"k", "d"=>"l", "e"=>"m", "f"=>"n", "g"=>"o",
-      "h"=>"p", "i"=>"q", "j"=>"r", "k"=>"s", "l"=>"t", "m"=>"u", "n"=>"v",
-      "o"=>"w", "p"=>"x", "q"=>"y", "r"=>"z", "s"=>" ", "t"=>"a", "u"=>"b",
-      "v"=>"c", "w"=>"d", "x"=>"e", "y"=>"f", "z"=>"g", " "=>"h"
-      }
-
-    d_expected = {
-      "a"=>"h", "b"=>"i", "c"=>"j", "d"=>"k", "e"=>"l", "f"=>"m", "g"=>"n",
-      "h"=>"o", "i"=>"p", "j"=>"q", "k"=>"r", "l"=>"s", "m"=>"t", "n"=>"u",
-      "o"=>"v", "p"=>"w", "q"=>"x", "r"=>"y", "s"=>"z", "t"=>" ", "u"=>"a",
-      "v"=>"b", "w"=>"c", "x"=>"d", "y"=>"e", "z"=>"f", " "=>"g"
-      }
-
-      assert_equal a_expected, enigma.decrypt_table("02715", "040895")[:a]
-      assert_equal b_expected, enigma.decrypt_table("02715", "040895")[:b]
-      assert_equal c_expected, enigma.decrypt_table("02715", "040895")[:c]
-      assert_equal d_expected, enigma.decrypt_table("02715", "040895")[:d]
+    assert_equal "ke((r o0u!w", cipher.encoded
   end
 
+  def test_it_coverts_capitalized_letter_to_lower_cased_letters
+    cipher = Cipher.new("HELLO world", "02715", "040895")
+
+    assert_equal "keder ohulw", cipher.encoded
+  end
+
+  def test_it_can_decode_a_message
+    cipher = Cipher.new("keder ohulw", "02715", "040895")
+
+    assert_equal "hello world", cipher.decoded
+  end
 
 end

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -12,7 +12,7 @@ class KeyTest < Minitest::Test
     assert_equal "00005", enigma_3.format_to_char_length("5", 5)
   end
 
-  def test_if_less_than_5_characters_zeros_can_be_prepended_upon_input
+  def test_if_less_than_five_characters_zeros_can_be_prepended_upon_input
     enigma_1 = Enigma.new
     enigma_2 = Enigma.new
     enigma_3 = Enigma.new
@@ -26,7 +26,7 @@ class KeyTest < Minitest::Test
     assert_equal "00005", enigma_3.encrypted[:key]
   end
 
-  def test_it_can_create_a_random_key_of_5_characters
+  def test_it_can_create_a_random_key_of_five_characters
     enigma_1 = Enigma.new
     enigma_2 = Enigma.new
 
@@ -38,7 +38,7 @@ class KeyTest < Minitest::Test
     assert_equal false, set_1 == set_2
   end
 
-  def test_if_no_key_is_given_a_random_5_character_key_is_created_and_assigned
+  def test_if_no_key_is_given_a_random_five_character_key_is_created_and_assigned
     enigma_1 = Enigma.new
     enigma_2 = Enigma.new
 
@@ -53,12 +53,11 @@ class KeyTest < Minitest::Test
 
   def test_it_has_four_different_key_values_after_evaluating_key_argument
     enigma = Enigma.new
-    enigma.encrypt("hello world", "02715", "040895")
 
-    assert_equal 02, enigma.a_key_values("02715")
-    assert_equal 27, enigma.b_key_values("02715")
-    assert_equal 71, enigma.c_key_values("02715")
-    assert_equal 15, enigma.d_key_values("02715")
+    assert_equal 02, enigma.key_table("02715")[:a]
+    assert_equal 27, enigma.key_table("02715")[:b]
+    assert_equal 71, enigma.key_table("02715")[:c]
+    assert_equal 15, enigma.key_table("02715")[:d]
   end
 
 end

--- a/test/offset_test.rb
+++ b/test/offset_test.rb
@@ -51,10 +51,10 @@ class OffsetTest < Minitest::Test
     enigma = Enigma.new
     enigma.encrypt("hello world", "02715", "040895")
 
-    assert_equal 1, enigma.a_offset_values("040895")
-    assert_equal 0, enigma.b_offset_values("040895")
-    assert_equal 2, enigma.c_offset_values("040895")
-    assert_equal 5, enigma.d_offset_values("040895")
+    assert_equal 1, enigma.offset_table("040895")[:a]
+    assert_equal 0, enigma.offset_table("040895")[:b]
+    assert_equal 2, enigma.offset_table("040895")[:c]
+    assert_equal 5, enigma.offset_table("040895")[:d]
   end
 
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -2,6 +2,19 @@ require './test/test_helper'
 
 class ShiftTest < Minitest::Test
 
+  def test_it_can_create_a_character_conversion_table
+    enigma = Enigma.new
+
+    expected = {
+      "a"=>"b", "b"=>"c", "c"=>"d", "d"=>"e", "e"=>"f", "f"=>"g", "g"=>"h",
+      "h"=>"i", "i"=>"j", "j"=>"k", "k"=>"l", "l"=>"m", "m"=>"n", "n"=>"o",
+      "o"=>"p", "p"=>"q", "q"=>"r", "r"=>"s", "s"=>"t", "t"=>"u", "u"=>"v",
+      "v"=>"w", "w"=>"x", "x"=>"y", "y"=>"z", "z"=>" ", " "=>"a"
+      }
+
+    assert_equal expected, enigma.conversion_table(1)
+  end
+
   def test_it_can_compile_total_shift_values_for_each_of_the_four_shift_factors
     enigma_1 = Enigma.new
     enigma_1.encrypt("hello world", "02715", "040895")
@@ -9,15 +22,15 @@ class ShiftTest < Minitest::Test
     enigma_2 = Enigma.new
     enigma_2.encrypt("hello world", "12345", "080589")
 
-    assert_equal 3, enigma_1.a_shift_value("02715", "040895")
-    assert_equal 27, enigma_1.b_shift_value("02715", "040895")
-    assert_equal 73, enigma_1.c_shift_value("02715", "040895")
-    assert_equal 20, enigma_1.d_shift_value("02715", "040895")
+    assert_equal 3, enigma_1.shift_table("02715", "040895")[:a]
+    assert_equal 27, enigma_1.shift_table("02715", "040895")[:b]
+    assert_equal 73, enigma_1.shift_table("02715", "040895")[:c]
+    assert_equal 20, enigma_1.shift_table("02715", "040895")[:d]
 
-    assert_equal 18, enigma_2.a_shift_value("12345", "080589")
-    assert_equal 32, enigma_2.b_shift_value("12345", "080589")
-    assert_equal 36, enigma_2.c_shift_value("12345", "080589")
-    assert_equal 46, enigma_2.d_shift_value("12345", "080589")
+    assert_equal 18, enigma_2.shift_table("12345", "080589")[:a]
+    assert_equal 32, enigma_2.shift_table("12345", "080589")[:b]
+    assert_equal 36, enigma_2.shift_table("12345", "080589")[:c]
+    assert_equal 46, enigma_2.shift_table("12345", "080589")[:d]
   end
 
   def test_it_can_create_a_cipher_table_for_each_encrypt_shift
@@ -95,5 +108,5 @@ class ShiftTest < Minitest::Test
       assert_equal c_expected, enigma.decrypt_table("02715", "040895")[:c]
       assert_equal d_expected, enigma.decrypt_table("02715", "040895")[:d]
   end
-  
+
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -20,4 +20,80 @@ class ShiftTest < Minitest::Test
     assert_equal 46, enigma_2.d_shift_value("12345", "080589")
   end
 
+  def test_it_can_create_a_cipher_table_for_each_encrypt_shift
+    enigma = Enigma.new
+    enigma.encrypt("hello world", "02715", "040895")
+
+    a_expected = {
+      "a"=>"d", "b"=>"e", "c"=>"f", "d"=>"g", "e"=>"h", "f"=>"i","g"=>"j",
+      "h"=>"k", "i"=>"l", "j"=>"m", "k"=>"n", "l"=>"o", "m"=>"p", "n"=>"q",
+      "o"=>"r", "p"=>"s", "q"=>"t", "r"=>"u", "s"=>"v", "t"=>"w", "u"=>"x",
+      "v"=>"y", "w"=>"z", "x"=>" ", "y"=>"a", "z"=>"b", " "=>"c"
+      }
+
+    b_expected = {
+      "a"=>"a", "b"=>"b", "c"=>"c", "d"=>"d", "e"=>"e", "f"=>"f", "g"=>"g",
+      "h"=>"h", "i"=>"i", "j"=>"j", "k"=>"k", "l"=>"l", "m"=>"m", "n"=>"n",
+      "o"=>"o", "p"=>"p", "q"=>"q", "r"=>"r", "s"=>"s", "t"=>"t", "u"=>"u",
+      "v"=>"v", "w"=>"w", "x"=>"x", "y"=>"y", "z"=>"z", " "=>" "
+      }
+
+    c_expected = {
+      "a"=>"t", "b"=>"u", "c"=>"v", "d"=>"w", "e"=>"x", "f"=>"y", "g"=>"z",
+      "h"=>" ", "i"=>"a", "j"=>"b", "k"=>"c", "l"=>"d", "m"=>"e", "n"=>"f",
+      "o"=>"g", "p"=>"h", "q"=>"i", "r"=>"j", "s"=>"k", "t"=>"l", "u"=>"m",
+      "v"=>"n", "w"=>"o", "x"=>"p", "y"=>"q", "z"=>"r", " "=>"s"
+      }
+
+    d_expected = {
+      "a"=>"u", "b"=>"v", "c"=>"w", "d"=>"x", "e"=>"y", "f"=>"z", "g"=>" ",
+      "h"=>"a", "i"=>"b", "j"=>"c", "k"=>"d", "l"=>"e", "m"=>"f", "n"=>"g",
+      "o"=>"h", "p"=>"i", "q"=>"j", "r"=>"k", "s"=>"l", "t"=>"m", "u"=>"n",
+      "v"=>"o", "w"=>"p", "x"=>"q", "y"=>"r", "z"=>"s", " "=>"t"
+      }
+
+    assert_equal a_expected, enigma.encrypt_table("02715", "040895")[:a]
+    assert_equal b_expected, enigma.encrypt_table("02715", "040895")[:b]
+    assert_equal c_expected, enigma.encrypt_table("02715", "040895")[:c]
+    assert_equal d_expected, enigma.encrypt_table("02715", "040895")[:d]
+  end
+
+  def test_it_can_create_a_cipher_table_for_each_decrypt_shift
+    enigma = Enigma.new
+    enigma.decrypt("keder ohulw", "02715", "040895")
+
+    a_expected = {
+      "a"=>"y", "b"=>"z", "c"=>" ", "d"=>"a", "e"=>"b", "f"=>"c", "g"=>"d",
+      "h"=>"e", "i"=>"f", "j"=>"g", "k"=>"h", "l"=>"i", "m"=>"j", "n"=>"k",
+      "o"=>"l", "p"=>"m", "q"=>"n", "r"=>"o", "s"=>"p", "t"=>"q", "u"=>"r",
+      "v"=>"s", "w"=>"t", "x"=>"u", "y"=>"v", "z"=>"w", " "=>"x"
+      }
+
+    b_expected = {
+      "a"=>"a", "b"=>"b", "c"=>"c", "d"=>"d", "e"=>"e", "f"=>"f", "g"=>"g",
+      "h"=>"h", "i"=>"i", "j"=>"j", "k"=>"k", "l"=>"l", "m"=>"m", "n"=>"n",
+      "o"=>"o", "p"=>"p", "q"=>"q", "r"=>"r", "s"=>"s", "t"=>"t", "u"=>"u",
+      "v"=>"v", "w"=>"w", "x"=>"x", "y"=>"y", "z"=>"z", " "=>" "
+      }
+
+    c_expected = {
+      "a"=>"i", "b"=>"j", "c"=>"k", "d"=>"l", "e"=>"m", "f"=>"n", "g"=>"o",
+      "h"=>"p", "i"=>"q", "j"=>"r", "k"=>"s", "l"=>"t", "m"=>"u", "n"=>"v",
+      "o"=>"w", "p"=>"x", "q"=>"y", "r"=>"z", "s"=>" ", "t"=>"a", "u"=>"b",
+      "v"=>"c", "w"=>"d", "x"=>"e", "y"=>"f", "z"=>"g", " "=>"h"
+      }
+
+    d_expected = {
+      "a"=>"h", "b"=>"i", "c"=>"j", "d"=>"k", "e"=>"l", "f"=>"m", "g"=>"n",
+      "h"=>"o", "i"=>"p", "j"=>"q", "k"=>"r", "l"=>"s", "m"=>"t", "n"=>"u",
+      "o"=>"v", "p"=>"w", "q"=>"x", "r"=>"y", "s"=>"z", "t"=>" ", "u"=>"a",
+      "v"=>"b", "w"=>"c", "x"=>"d", "y"=>"e", "z"=>"f", " "=>"g"
+      }
+
+      assert_equal a_expected, enigma.decrypt_table("02715", "040895")[:a]
+      assert_equal b_expected, enigma.decrypt_table("02715", "040895")[:b]
+      assert_equal c_expected, enigma.decrypt_table("02715", "040895")[:c]
+      assert_equal d_expected, enigma.decrypt_table("02715", "040895")[:d]
+  end
+  
 end


### PR DESCRIPTION
In the key, offset, and shift modules - methods which were repeated for each of the (a,b,c,d) shifts were consolidated into tables for each respective module to DRY things up. Tests and other integrated methods were modified as needed to correctly reference the new tables.